### PR TITLE
fix: pin exact pnpm version to avoid action-setup self-update crash [no-deploy]

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pin exact version (not just major "11") to avoid pnpm/action-setup's
+          # self-update step, which has a known crash bug: pnpm/pnpm#10643
+          version: 11.13.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pin exact version (not just major "11") to avoid pnpm/action-setup's
+          # self-update step, which has a known crash bug: pnpm/pnpm#10643
+          version: 11.13.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -76,7 +76,9 @@ jobs:
         if: steps.check-skip.outputs.skip_deploy != 'true'
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pin exact version (not just major "11") to avoid pnpm/action-setup's
+          # self-update step, which has a known crash bug: pnpm/pnpm#10643
+          version: 11.13.0
 
       - name: Install dependencies
         if: steps.check-skip.outputs.skip_deploy != 'true'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipsplit",
-  "version": "1.21.25",
+  "version": "1.21.26",
   "type": "module",
   "scripts": {
     "reset-packages": "rm -rf node_modules && rm -rf pnpm-lock.yaml && pnpm install",


### PR DESCRIPTION
pnpm/action-setup with only a major version (11) triggers pnpm's own self-update step, which has a known crash bug (pnpm/pnpm#10643) that broke the scheduled Reconcile Dependabot Overrides run.