### PR TITLE
fix: bump pinned pnpm version from broken 11.13.0 to 11.19.0

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -44,7 +44,9 @@ jobs:
         with:
           # Pin exact version (not just major "11") to avoid pnpm/action-setup's
           # self-update step, which has a known crash bug: pnpm/pnpm#10643
-          version: 11.13.0
+          # 11.13.0 itself later turned out to ship a broken @pnpm/exe binary
+          # (pnpm/pnpm#13067) - bumped to 11.19.0.
+          version: 11.19.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -40,13 +40,10 @@ jobs:
           node-version: '22'
 
       - name: Install pnpm
+        # Version is read from package.json's "packageManager" field (single
+        # source of truth). Omitting it here avoids pnpm/action-setup's
+        # self-update step, which has a known crash bug: pnpm/pnpm#10643.
         uses: pnpm/action-setup@v6
-        with:
-          # Pin exact version (not just major "11") to avoid pnpm/action-setup's
-          # self-update step, which has a known crash bug: pnpm/pnpm#10643
-          # 11.13.0 itself later turned out to ship a broken @pnpm/exe binary
-          # (pnpm/pnpm#13067) - bumped to 11.19.0.
-          version: 11.19.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           # Pin exact version (not just major "11") to avoid pnpm/action-setup's
           # self-update step, which has a known crash bug: pnpm/pnpm#10643
-          version: 11.13.0
+          # 11.13.0 itself later turned out to ship a broken @pnpm/exe binary
+          # (pnpm/pnpm#13067) - bumped to 11.19.0.
+          version: 11.19.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -30,13 +30,10 @@ jobs:
           node-version: "22"
 
       - name: Install pnpm
+        # Version is read from package.json's "packageManager" field (single
+        # source of truth). Omitting it here avoids pnpm/action-setup's
+        # self-update step, which has a known crash bug: pnpm/pnpm#10643.
         uses: pnpm/action-setup@v6
-        with:
-          # Pin exact version (not just major "11") to avoid pnpm/action-setup's
-          # self-update step, which has a known crash bug: pnpm/pnpm#10643
-          # 11.13.0 itself later turned out to ship a broken @pnpm/exe binary
-          # (pnpm/pnpm#13067) - bumped to 11.19.0.
-          version: 11.19.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -84,7 +84,9 @@ jobs:
         with:
           # Pin exact version (not just major "11") to avoid pnpm/action-setup's
           # self-update step, which has a known crash bug: pnpm/pnpm#10643
-          version: 11.13.0
+          # 11.13.0 itself later turned out to ship a broken @pnpm/exe binary
+          # (pnpm/pnpm#13067) - bumped to 11.19.0.
+          version: 11.19.0
 
       - name: Install dependencies
         if: steps.check-skip.outputs.skip_deploy != 'true'

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -80,13 +80,10 @@ jobs:
 
       - name: Install pnpm
         if: steps.check-skip.outputs.skip_deploy != 'true'
+        # Version is read from package.json's "packageManager" field (single
+        # source of truth). Omitting it here avoids pnpm/action-setup's
+        # self-update step, which has a known crash bug: pnpm/pnpm#10643.
         uses: pnpm/action-setup@v6
-        with:
-          # Pin exact version (not just major "11") to avoid pnpm/action-setup's
-          # self-update step, which has a known crash bug: pnpm/pnpm#10643
-          # 11.13.0 itself later turned out to ship a broken @pnpm/exe binary
-          # (pnpm/pnpm#13067) - bumped to 11.19.0.
-          version: 11.19.0
 
       - name: Install dependencies
         if: steps.check-skip.outputs.skip_deploy != 'true'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipsplit",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "type": "module",
   "scripts": {
     "reset-packages": "rm -rf node_modules && rm -rf pnpm-lock.yaml && pnpm install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipsplit",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "type": "module",
   "packageManager": "pnpm@11.19.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pipsplit",
   "version": "1.24.3",
   "type": "module",
+  "packageManager": "pnpm@11.19.0",
   "scripts": {
     "reset-packages": "rm -rf node_modules && rm -rf pnpm-lock.yaml && pnpm install",
     "ng": "ng",


### PR DESCRIPTION
pnpm 11.13.0 shipped a broken @pnpm/exe binary (pnpm/pnpm#13067), which just failed the release deploy at the Install pnpm step. Still pinning an exact version rather than a floating major/latest, since that's what caused the original crash bug this pin was meant to avoid.