### PR TITLE
fix: switch App Check to ReCaptchaEnterpriseProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipsplit",
-  "version": "1.24.4",
+  "version": "1.24.5",
   "type": "module",
   "packageManager": "pnpm@11.19.0",
   "scripts": {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -27,7 +27,10 @@ import { provideTranslateService } from '@ngx-translate/core';
 import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 import { PageTitleStrategyService } from '@services/page-title-strategy.service';
 import { initializeApp } from 'firebase/app';
-import { initializeAppCheck, ReCaptchaV3Provider } from 'firebase/app-check';
+import {
+  initializeAppCheck,
+  ReCaptchaEnterpriseProvider,
+} from 'firebase/app-check';
 import { connectAuthEmulator, getAuth } from 'firebase/auth';
 import { connectFirestoreEmulator, getFirestore } from 'firebase/firestore';
 import { connectFunctionsEmulator, getFunctions } from 'firebase/functions';
@@ -52,7 +55,7 @@ const app = initializeApp(firebaseConfig);
 const isBrowser = typeof window !== 'undefined';
 if (isBrowser && !useEmulators) {
   initializeAppCheck(app, {
-    provider: new ReCaptchaV3Provider(appCheckConfig.recaptchaSiteKey),
+    provider: new ReCaptchaEnterpriseProvider(appCheckConfig.recaptchaSiteKey),
     isTokenAutoRefreshEnabled: true,
   });
 }


### PR DESCRIPTION
## Summary
- Production App Check verification failed after the last deploy: the exchangeRecaptchaV3Token call returned 403 "App attestation failed."
- Root cause: Google's reCAPTCHA admin console now provisions reCAPTCHA Enterprise keys by default (2026 migration to Google Cloud's Fraud Defense product), even for "v3-scored" keys - classic v3 keys can no longer be newly created.
- Switched `src/app/app.config.ts` from `ReCaptchaV3Provider` to `ReCaptchaEnterpriseProvider`, matching the key type actually issued.
- The reCAPTCHA Enterprise provider is now registered in the Firebase App Check console for the web app (confirmed via screenshot, both reCAPTCHA and reCAPTCHA Enterprise show "Registered").

## Test plan
- [x] `ng build` succeeds
- [ ] Post-deploy: re-run the production verification check and confirm exchangeRecaptchaV3Token / equivalent Enterprise exchange returns 200, not 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)